### PR TITLE
Fixes pm2 and CentOS' Git

### DIFF
--- a/nadekoautoinstaller.sh
+++ b/nadekoautoinstaller.sh
@@ -383,9 +383,9 @@ elif [ "$OS" = "CentOS" ]; then
 		sudo yum install libunwind libicu -y
 		sudo rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
 		sudo yum -y install http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm epel-release
-		sudo yum install git opus opus-devel ffmpeg tmux yum-utils -y
-		sudo yum -y groupinstall development
 		sudo yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+		sudo yum install git2u opus opus-devel ffmpeg tmux yum-utils -y
+		sudo yum -y groupinstall development
 		sudo yum --obsoletes --exclude=kernel* update -y
 		sudo yum install python python36u python36u-pip python36u-devel dotnet-sdk-2.1 -y
 		sudo yum install redis -y

--- a/nadekopm2setup.sh
+++ b/nadekopm2setup.sh
@@ -84,7 +84,7 @@ read -n 1 -s -p "Press any key to continue..."
 	sudo apt-get install -y build-essential
 	sudo npm i -g npm
 	echo "Installing pm2..."
-	sudo npm install pm2 -g
+	sudo npm install pm2@3.1.3 -g
 fi
 	
 if [ "$OS" = "Debian" ]; then
@@ -99,7 +99,7 @@ read -n 1 -s -p "Press any key to continue..."
 	sudo apt-get install -y build-essential
 	sudo npm i -g npm
 	echo "Installing pm2..."
-	sudo npm install pm2 -g
+	sudo npm install pm2@3.1.3 -g
 fi
 	
 if [ "$OS" = "LinuxMint" ]; then
@@ -114,7 +114,7 @@ read -n 1 -s -p "Press any key to continue..."
 	sudo apt-get install -y build-essential
 	sudo npm i -g npm
 	echo "Installing pm2..."
-	sudo npm install pm2 -g
+	sudo npm install pm2@3.1.3 -g
 fi
 
 if [ "$OS" = "CentOS" ]; then
@@ -129,7 +129,7 @@ read -n 1 -s -p "Press any key to continue..."
 	sudo yum install gcc-c++ make
 	sudo npm i -g npm
 	echo "Installing pm2..."
-	sudo npm install pm2 -g
+	sudo npm install pm2@3.1.3 -g
 fi
 
 


### PR DESCRIPTION
From now on, the script should install pm2 3.1.3 on new Nadeko installations. This version is not bugged and shows no issues with stopping instances of Nadeko to resume them later on.

CentOS should now get the version 2.16.5 of Git. It's not the latest one, but should be enough to process the GitLab link successfully.