### PR TITLE
Systemd Compatible Scripts for Linux

### DIFF
--- a/systemd-scripts/nadeko-service-create.sh
+++ b/systemd-scripts/nadeko-service-create.sh
@@ -52,7 +52,6 @@ cp $srvFile $HOME/.config/systemd/user/$srvFile
 cp $updFile $HOME/.config/systemd/user/$updFile
 cp $timFile $HOME/.config/systemd/user/$timFile
 
-exit 0
 echo Enabling services.
 /bin/systemctl --user enable nadeko.service
 /bin/systemctl --user enable nadeko-update.timer

--- a/systemd-scripts/nadeko-service-create.sh
+++ b/systemd-scripts/nadeko-service-create.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+botRoot="$(dirname "$(realpath "$0")")"
+cd "$botRoot"
+srvFile=nadeko.service
+updFile=nadeko-update.service
+timFile=nadeko-update.timer
+
+echo This script will generate and install systemd user service units for the
+echo bot itself the update script to run automatically.
+
+echo Generating $srvFile
+echo "[Unit]" > $srvFile
+echo "Description=NadekoBot Update Service" >> $srvFile
+echo  >> $srvFile
+echo "[Service]" >> $srvFile
+echo "Type=simple" >> $srvFile
+echo "ExecStart=$botRoot/nadeko.sh" >> $srvFile
+echo "WorkingDirectory=$botRoot" >> $srvFile
+echo "StandardOutput=file:$botRoot/nadeko.log" >> $srvFile
+echo "StandardError=file:$botRoot/nadeko.log" >> $srvFile
+echo  >> $srvFile
+echo "[Install]" >> $srvFile
+echo "WantedBy=multi-user.target" >> $srvFile
+
+echo Generating $updFile
+echo "[Unit]" > $updFile
+echo "Description=NadekoBot Update Service" >> $updFile
+echo  >> $updFile
+echo "[Service]" >> $updFile
+echo "Type=simple" >> $updFile
+echo "ExecStart=$botRoot/nadeko-update.sh" >> $updFile
+echo "WorkingDirectory=$botRoot" >> $updFile
+echo "StandardOutput=file:$botRoot/nadeko-update.log" >> $updFile
+echo "StandardError=file:$botRoot/nadeko-update.log" >> $updFile
+echo  >> $updFile
+echo "[Install]" >> $srvFile
+echo "WantedBy=multi-user.target" >> $srvFile
+
+echo Generating $timFile
+echo "[Unit]" > $timFile
+echo "Description=NadekoBot Update Service" >> $timFile
+echo >> $timFile
+echo "[Timer]" >> $timFile
+echo "OnCalendar=*-*-* 03:30:00" >> $timFile
+echo "Persistent=True" >> $timFile
+echo >> $timFile
+echo "[Install]" >> $timFile
+echo "WantedBy=timers.target" >> $timFile
+
+echo Installing service units.
+cp $srvFile $HOME/.config/systemd/user/$srvFile
+cp $updFile $HOME/.config/systemd/user/$updFile
+cp $timFile $HOME/.config/systemd/user/$timFile
+
+echo Enabling services.
+/bin/systemctl --user enable nadeko.service
+/bin/systemctl --user enable nadeko-update.timer
+/bin/systemctl --user start nadeko.service
+
+echo Service units should not be installed and the bot should be running.
+echo To stop the bot type: systemctl --user stop nadeko
+echo To start/restart the bot replace stop with the appropriate command.
+echo
+echo The update timer will execute daily at 3:30am. 

--- a/systemd-scripts/nadeko-service-create.sh
+++ b/systemd-scripts/nadeko-service-create.sh
@@ -52,6 +52,7 @@ cp $srvFile $HOME/.config/systemd/user/$srvFile
 cp $updFile $HOME/.config/systemd/user/$updFile
 cp $timFile $HOME/.config/systemd/user/$timFile
 
+exit 0
 echo Enabling services.
 /bin/systemctl --user enable nadeko.service
 /bin/systemctl --user enable nadeko-update.timer

--- a/systemd-scripts/nadeko-update.sh
+++ b/systemd-scripts/nadeko-update.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+rootPath="$(dirname "$(realpath "$0")")"
+cd "$rootPath"
+tempDir=NadekoTemp
+
+if [ -d $tempDir ]; then
+	rm -r $tempDir
+fi	
+mkdir $tempDir
+cd $tempDir
+
+echo Stopping NadekoBot for update.
+/bin/systemctl --user stop nadeko.service
+
+echo Beginning NadekoBot Update.
+echo
+echo Downloading NadekoBot...
+git clone -b 1.9 --recursive --depth 1 https://gitlab.com/Kwoth/NadekoBot
+echo Download complete.
+echo
+
+echo Rebuilding NadekoBot...
+cd "$rootPath"/$tempDir/NadekoBot
+/usr/bin/dotnet restore
+/usr/bin/dotnet build --configuration Release
+echo Rebuild complete.
+echo
+
+cd "$rootPath"
+if [ ! -d NadekoBot ]; then
+    mv $tempDir/NadekoBot NadekoBot
+else
+	backupDir=NadekoBot.backup
+	releaseDir=src/NadekoBot/bin/Release
+	echo Backing up previous build...
+	if [ -d $backupDir ]; then
+	    rm -rf NadekoBot.backup
+	fi
+    mv -fT NadekoBot NadekoBot.backup
+    
+    echo Installing updated build...
+    mv $tempDir/NadekoBot NadekoBot
+    
+    echo Copying data from the previous build...
+    cd "$rootPath"
+    
+    if [ -f ./$backupDir/src/NadekoBot/credentials.json ]; then
+	    cp -f ./$backupDir/src/NadekoBot/credentials.json ./NadekoBot/src/NadekoBot/credentials.json
+	    cp -f ./$backupDir/src/NadekoBot/credentials.json ./NadekoBot/src/NadekoBot/credentials.backup.json
+	else
+		echo Warning, no credentials found in the current install!
+    fi
+
+	if [ -f ./$backupDir/$releaseDir/netcoreapp1.0/data/NadekoBot.db ]; then
+	    cp -T ./$backupDir/$releaseDir/netcoreapp1.0/data/NadekoBot.db ./NadekoBot/$releaseDir/netcoreapp2.1/data/NadekoBot.db
+	    cp -T ./$backupDir/$releaseDir/netcoreapp1.0/data/NadekoBot.db ./NadekoBot/$releaseDir/netcoreapp2.1/data/NadekoBot-1.0.backup.db
+	elif [ -f ./$backupDir/$releaseDir/netcoreapp1.1/data/NadekoBot.db ]; then
+		cp -T ./$backupDir/$releaseDir/netcoreapp1.1/data/NadekoBot.db ./NadekoBot/$releaseDir/netcoreapp2.1/data/NadekoBot.db
+		cp -T ./$backupDir/$releaseDir/netcoreapp1.1/data/NadekoBot.db ./NadekoBot/$releaseDir/netcoreapp2.1/data/NadekoBot-1.1.backup.db
+    elif [ -f ./$backupDir/$releaseDir/netcoreapp2.0/data/NadekoBot.db ]; then
+	    cp -T ./$backupDir/$releaseDir/netcoreapp2.0/data/NadekoBot.db ./NadekoBot/$releaseDir/netcoreapp2.1/data/NadekoBot.db
+	    cp -T ./$backupDir/$releaseDir/netcoreapp2.0/data/NadekoBot.db ./NadekoBot/$releaseDir/netcoreapp2.1/data/NadekoBot-2.0.backup.db
+	elif [ -d ./$backupDir/$releaseDir/netcoreapp2.1/data ]; then
+	    cp ./$backupDir/$releaseDir/netcoreapp2.1/data/*.db ./NadekoBot/$releaseDir/netcoreapp2.1/data
+	    cp ./$backupDir/$releaseDir/netcoreapp2.1/data/NadekoBot.db ./NadekoBot/$releaseDir/netcoreapp2.1/data/NadekoBot.backup.db
+    else
+    	echo Database not found from previous build!
+    fi
+
+	if [ -d ./$backupDir/src/NadekoBot/data ]; then
+	    cp -r ./$backupDir/src/NadekoBot/data/ ./NadekoBot/src/NadekoBot/data/
+	else
+		echo Warning no data directory found from previous build!
+	fi
+	
+	echo All data copied from previous build.
+    echo
+fi
+
+rm -r $tempDir
+echo Update complete.
+
+echo Starting NadekoBot with new build.
+/bin/systemctl --user start nadeko.service

--- a/systemd-scripts/nadeko.sh
+++ b/systemd-scripts/nadeko.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+cd "$(dirname "$(realpath "$0")")"/NadekoBot
+
+echo Updating YouTube download library.
+/usr/local/bin/youtube-dl -U
+
+echo Rebuilding NadekoBot...
+/usr/bin/dotnet restore
+/usr/bin/dotnet build -c Release
+
+cd src/NadekoBot
+echo Running NadekoBot...
+/usr/bin/dotnet run -c Release


### PR DESCRIPTION
I hope these help, this will get away from using PM2 which exposes a serious security problem running a user-facing service (on a chat server no less) as root on linux systems.  These scripts will allow service units for systemd to be generated and run / update the bot.  The bot would be executed after all system-level services are started as a user service and will not have root privileges.  The `nadeko-update.service` unit should remain disabled, it will be fired by `nadeko-update.timer` which will run once a day at 3:30am where it will shut down the bot's service, update, and restart the bot.  If `nadeko-update.service` is enabled it could cause issues at boot where the bot will run from `nadeko.service` and then `nadeko-update.service` stops the bot, updates, and starts it.